### PR TITLE
Update analyzer

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ^3.9.0
 
 dependencies:
-  analyzer: ^8.4.0
+  analyzer: ^10.2.0
   args: ^2.5.0
   isolate_manager: ^6.1.2
   path: ^1.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ^3.9.0
 
 dependencies:
-  analyzer: ^10.2.0
+  analyzer: ^10.0.0
   args: ^2.5.0
   isolate_manager: ^6.1.2
   path: ^1.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: isolate_manager_generator
 description: "The generator for the isolate_manager"
-version: 0.3.0
+version: 0.3.1
 homepage: https://github.com/lamnhan066/isolate_manager_generator
 
 environment:


### PR DESCRIPTION
Updates the analyzer dependency to pin to 10.0.0 as a minimum version. I was having dependency issues due to upgrading drift_dev to version 2.32 due to package conflicts on analyzer.

APIs in use are unchanged by the change. 